### PR TITLE
Corrected mismatch between .256/.384 cases and returned algorithm values

### DIFF
--- a/Sources/EllipticCurveKeyPair.swift
+++ b/Sources/EllipticCurveKeyPair.swift
@@ -795,9 +795,9 @@ public enum EllipticCurveKeyPair {
             case .sha224:
                 return SecKeyAlgorithm.eciesEncryptionStandardX963SHA224AESGCM
             case .sha256:
-                return SecKeyAlgorithm.eciesEncryptionStandardX963SHA384AESGCM
-            case .sha384:
                 return SecKeyAlgorithm.eciesEncryptionStandardX963SHA256AESGCM
+            case .sha384:
+                return SecKeyAlgorithm.eciesEncryptionStandardX963SHA384AESGCM
             case .sha512:
                 return SecKeyAlgorithm.eciesEncryptionStandardX963SHA512AESGCM
             }


### PR DESCRIPTION
The .sha256 case had returned the algorithm for SHA384AESGCM, while .sha384 returned SHA256. Switched them back.