### PR TITLE
Public initializer for EllipticCurveKeyPair.Helper

### DIFF
--- a/Sources/EllipticCurveKeyPair.swift
+++ b/Sources/EllipticCurveKeyPair.swift
@@ -207,6 +207,8 @@ public enum EllipticCurveKeyPair {
         // The user visible label in the device's key chain
         public let config: Config
         
+        public init() {}
+        
         public func getPublicKey() throws -> PublicKey {
             return try Query.getPublicKey(labeled: config.publicLabel, accessGroup: config.publicKeyAccessGroup)
         }


### PR DESCRIPTION
The default initializers for public structs in Swift is `internal` [1] which prevents `EllipticCurveKeyPair.Helper` from being instantiated. This reduces flexibility in the design because the only way to use `EllipticCurveKeyPair.Helper` is through the opinionated `EllipticCurveKeyPair.Manager` class. 

Class documentation for both `Manager` and `Helper` seem to suggest that wrapping `Helper` in a facade is intended functionality, which is currently not available. 

[1] https://docs.swift.org/swift-book/LanguageGuide/AccessControl.html#ID19