### PR TITLE
- swift 5 compatibility

### DIFF
--- a/Sources/SHA256.swift
+++ b/Sources/SHA256.swift
@@ -155,8 +155,8 @@ final public class SHA256 {
             bytes[totalBytes - 1 - j] = (bytesPointer + j).pointee
         }
         
-        valuePointer.deinitialize()
-        valuePointer.deallocate(capacity: 1)
+        valuePointer.deinitialize(count: 1)
+        valuePointer.deallocate()
         
         return bytes
     }


### PR DESCRIPTION
Just a small change since the deallocate/deinit methods were changed/deprecated in swift 4.1 and completely removed in 5.0. As per https://github.com/apple/swift-evolution/blob/master/proposals/0184-unsafe-pointers-add-missing.md

This change preserves the same behaviour, with the new API.
