### PR TITLE
Update Package.swift for tools version 5.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,23 @@
+// swift-tools-version:5.1
 import PackageDescription
 
 let package = Package(
-    name: "EllipticCurveKeyPair"
+    name: "EllipticCurveKeyPair",
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "EllipticCurveKeyPair",
+            targets: ["EllipticCurveKeyPair"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "EllipticCurveKeyPair",
+            path: "Sources"),
+    ]
 )


### PR DESCRIPTION
Old Package.swift does not work good with Xcode 11, probably it's time to move on :)