### PR TITLE
Fix build on Xcode 16.3 beta1

### DIFF
--- a/Sources/EllipticCurveKeyPair.swift
+++ b/Sources/EllipticCurveKeyPair.swift
@@ -865,7 +865,11 @@ public enum EllipticCurveKeyPair {
         }
         
         public static var isSimulator: Bool {
-            return TARGET_OS_SIMULATOR != 0
+            #if targetEnvironment(simulator)
+            return true
+            #else
+            return false
+            #endif
         }
         
         public static var hasSecureEnclave: Bool {


### PR DESCRIPTION
It does not build on Xcode 16.3 beta1.
`TARGET_OS_SIMULATOR` has been introduced in iOS 9 but weirdly it does not pick it up anymore?

I switched to a pure Swift based solution that compiler should handle by itself instead on relying on headers inclusivity